### PR TITLE
Add important "Fpdf scripts" as traits

### DIFF
--- a/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
+++ b/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Fpdf\Traits\MemoryImageSupport;
+/*******************************************************************************
+ * FPDF-Script: Memory image support                                           *
+ *                                                                             *
+ * Date:    2004-04-05                                                         *
+ * Author:  Olivier PLATHEY                                                    *
+ *******************************************************************************/
+
+trait MemImageTrait
+{
+    private $memImageInitialized = false;
+
+    /**
+     * Constructors do not work well in traits. It's better to create our own initialization.
+     */
+    private function memImageInitialize()
+    {
+        if ($this->memImageInitialized || in_array('var', stream_get_wrappers())) {
+            return;
+        }
+
+        stream_wrapper_register('var', VariableStream::class);
+    }
+
+    public function MemImage($data, $x=null, $y=null, $w=0, $h=0, $link='')
+    {
+        $this->memImageInitialize();
+
+        // Display the image contained in $data
+        $v = 'img'.md5($data);
+        $GLOBALS[$v] = $data;
+        $a = getimagesize('var://'.$v);
+        if(!$a)
+            $this->Error('Invalid image data');
+        $type = substr(strstr($a['mime'],'/'),1);
+        $this->Image('var://'.$v, $x, $y, $w, $h, $type, $link);
+        unset($GLOBALS[$v]);
+    }
+
+    public function GDImage($im, $x=null, $y=null, $w=0, $h=0, $link='')
+    {
+        $this->memImageInitialize();
+
+        // Display the GD image associated with $im
+        ob_start();
+        imagepng($im);
+        $data = ob_get_clean();
+        $this->MemImage($data, $x, $y, $w, $h, $link);
+    }
+}

--- a/src/Fpdf/Traits/MemoryImageSupport/VariableStream.php
+++ b/src/Fpdf/Traits/MemoryImageSupport/VariableStream.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Fpdf\Traits\MemoryImageSupport;
+
+
+
+class VariableStream
+{
+    private $varname;
+    private $position;
+
+    function stream_open($path, $mode, $options, &$opened_path)
+    {
+        $url = parse_url($path);
+        $this->varname = $url['host'];
+        if(!isset($GLOBALS[$this->varname]))
+        {
+            trigger_error('Global variable '.$this->varname.' does not exist', E_USER_WARNING);
+            return false;
+        }
+        $this->position = 0;
+        return true;
+    }
+
+    function stream_read($count)
+    {
+        $ret = substr($GLOBALS[$this->varname], $this->position, $count);
+        $this->position += strlen($ret);
+        return $ret;
+    }
+
+    function stream_eof()
+    {
+        return $this->position >= strlen($GLOBALS[$this->varname]);
+    }
+
+    function stream_tell()
+    {
+        return $this->position;
+    }
+
+    function stream_seek($offset, $whence)
+    {
+        if($whence==SEEK_SET)
+        {
+            $this->position = $offset;
+            return true;
+        }
+        return false;
+    }
+
+    function stream_stat()
+    {
+        return array();
+    }
+}


### PR DESCRIPTION
Hello there

I think, it would make a lot of sense to add some scripts as traits to this package, so they are easy to use right out of the box.

These extension traits would be easy to use like this:
```php
$fpdf = new class extends Fpdf\Fpdf {
    use Fpdf\Traits\MemoryImageSupport\MemImageTrait;
}

// [...]

$fpdf->MemImage($logo, 50, 30)
```