### PR TITLE
Add Laravel Alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,12 @@
   },
   "archive": {
     "exclude": ["original"]
+  },
+  "extra": {
+    "laravel": {        
+        "aliases": {
+            "FPDF": "Fpdf\\Fpdf"
+        }
+    }
   }
 }


### PR DESCRIPTION
https://laravel.com/docs/9.x/packages

This allow us to use the original class name on laravel instead of `Fpdf\Fpdf`, 
also it allows us to use [Setasign/FPDI](https://github.com/Setasign/FPDI) with this package

https://github.com/Setasign/FPDI/blob/273ab1544a6a53aa7beb6f14366586a9dd3369c5/src/FpdfTpl.php#L18