### PR TITLE
Fix unused memImageInitialized flag

### DIFF
--- a/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
+++ b/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
@@ -22,6 +22,7 @@ trait MemImageTrait
         }
 
         stream_wrapper_register('var', VariableStream::class);
+        $this->memImageInitialized = true;
     }
 
     public function MemImage($data, $x=null, $y=null, $w=0, $h=0, $link='')


### PR DESCRIPTION
Seems like `private $memImageInitialized = false;` is never used but there is a conditional for that
https://github.com/coreydoughty/Fpdf/blob/201e7e3e09f6cd05319def4dafc5afc001b44608/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php#L18-L20