### PR TITLE
Remove duplicate initialization

### DIFF
--- a/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
+++ b/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php
@@ -42,8 +42,6 @@ trait MemImageTrait
 
     public function GDImage($im, $x=null, $y=null, $w=0, $h=0, $link='')
     {
-        $this->memImageInitialize();
-
         // Display the GD image associated with $im
         ob_start();
         imagepng($im);


### PR DESCRIPTION
Remove unnecessary initialization
`GDImage` calls to `MemImage` and `MemImage` already calls `memImageInitialize`
https://github.com/coreydoughty/Fpdf/blob/92e6ea5ef4c7b9d2e724a69b6af2497e26b044fc/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php#L28-L30
https://github.com/coreydoughty/Fpdf/blob/92e6ea5ef4c7b9d2e724a69b6af2497e26b044fc/src/Fpdf/Traits/MemoryImageSupport/MemImageTrait.php#L43-L51

