### PR TITLE
Fix imagedestroy deprecation

### DIFF
--- a/original/fpdf.php
+++ b/original/fpdf.php
@@ -1443,7 +1443,6 @@ protected function _parsegif($file)
 	ob_start();
 	imagepng($im);
 	$data = ob_get_clean();
-	imagedestroy($im);
 	$f = fopen('php://temp','rb+');
 	if(!$f)
 		$this->Error('Unable to create memory stream');

--- a/src/Fpdf/Fpdf.php
+++ b/src/Fpdf/Fpdf.php
@@ -1445,7 +1445,6 @@ protected function _parsegif($file)
 	ob_start();
 	imagepng($im);
 	$data = ob_get_clean();
-	imagedestroy($im);
 	$f = fopen('php://temp','rb+');
 	if(!$f)
 		$this->Error('Unable to create memory stream');


### PR DESCRIPTION
https://www.php.net/manual/en/function.imagedestroy.php
> **Warning** This function has been _DEPRECATED_ as of PHP 8.5.0. Relying on this function is highly discouraged.
>
> **Note:** This function has no effect. Prior to PHP 8.0.0